### PR TITLE
Fix Issue #3

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,11 +30,11 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i%12)+1
+      month = (entry.month.to_i)
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),
-        month: month - 1,
+        month: month,
         year: year,
         article_count: entry.count
       }

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i)
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
This merge will fix issue #3 

It's the same solution for issue #2. Using the modulo method creates a bug with the year. If you want to fix the links and make sure December 2015 is clickable, you had to go to _content and remove the one again.
