### PR TITLE
Fixes Issue #2 and #3

### DIFF
--- a/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/lib/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -5,7 +5,7 @@
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>
         <li>
-          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]+1) ) %>
+          <%= link_to"#{month[:name]} #{counter}".html_safe,  articles_by_month_path( month[:year], "%02i" % (month[:month]) ) %>
         </li>
       <% end %>
     </ul>

--- a/lib/archives_sidebar/lib/archives_sidebar.rb
+++ b/lib/archives_sidebar/lib/archives_sidebar.rb
@@ -30,11 +30,11 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i%12)+1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),
-        month: month - 1,
+        month: month,
         year: year,
         article_count: entry.count
       }


### PR DESCRIPTION
Fixed issue #2 

Since the articles are being parsed based on their created timestamp, and the year is not being monkeyed-about with, there's no reason for the code to monkey-about with the incoming month data either. Removed the random `+` and `- 1`'s~~, as well as the unknown-purpose %12. Restart rails server and bob's-your-uncle.~~

**Edit:**

Upon further review, this also resolves issue #3 :

Removing the `%12` fixes the disorder which was causing the months to appear out-of-order
